### PR TITLE
Implement Axios error logging

### DIFF
--- a/src/app/Core/HttpResourceApi.ts
+++ b/src/app/Core/HttpResourceApi.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosResponse, AxiosRequestConfig } from 'axios';
 import {Application} from "../Domain/Application";
+import {HttpErrorEvent} from "../Events/HttpErrorEvent";
 
 type verbString = 'get' | 'post' | 'put' | 'patch' | 'delete';
 
@@ -58,6 +59,15 @@ export class HttpResourceApi {
   }
 
   private handleError(error: AxiosError): void {
-
+    if (error.response) {
+      const status = error.response.status;
+      const url = error.config?.url ?? 'unknown url';
+      console.error(`Request to ${url} failed with status ${status}`, error.response.data);
+    } else if (error.request) {
+      console.error('No response received:', error.message);
+    } else {
+      console.error('Error setting up request:', error.message);
+    }
+    new HttpErrorEvent(error).Publish();
   }
 }

--- a/src/app/Events/HttpErrorEvent.ts
+++ b/src/app/Events/HttpErrorEvent.ts
@@ -1,0 +1,8 @@
+import {AppEvent} from "../Core/AppEvent";
+import {AxiosError} from "axios";
+
+export class HttpErrorEvent extends AppEvent {
+  constructor(public readonly Error: AxiosError) {
+    super();
+  }
+}


### PR DESCRIPTION
## Summary
- log errors in `HttpResourceApi` and publish a new `HttpErrorEvent`
- add `HttpErrorEvent` class for error propagation

## Testing
- `npm test` *(fails: ng not found)*