### PR TITLE
Add Growth Trader screen

### DIFF
--- a/src/app/App.Module.ts
+++ b/src/app/App.Module.ts
@@ -18,6 +18,7 @@ import { LoginScreenComponent } from './Components/Screens/LoginScreen/LoginScre
 import {MatIconModule} from "@angular/material/icon";
 import {ScreenLayoutComponent} from "./Components/Layout/ScreenLayout.Component";
 import {TrailingTradesComponent} from "./Components/Screens/TrailingTradesScreen/TrailingTrades.Component";
+import {GrowthTraderComponent} from "./Components/Screens/GrowthTraderScreen/GrowthTrader.Component";
 import {MatSelectModule} from "@angular/material/select";
 import {TradeRowComponent} from "./Components/Screens/TrailingTradesScreen/TradeRow/TradeRow.Component";
 import {TextBoxComponent} from "./Components/Controls/TextBox/TextBox.Component";
@@ -31,6 +32,7 @@ import {DropDownComponent} from "./Components/Controls/DropDown/DropDown.Compone
     LoginScreenComponent,
     ScreenLayoutComponent,
     TrailingTradesComponent,
+    GrowthTraderComponent,
     TradeRowComponent,
     TextBoxComponent,
     DropDownComponent

--- a/src/app/App.Routing.ts
+++ b/src/app/App.Routing.ts
@@ -4,6 +4,7 @@ import { LoginScreenComponent } from "./Components/Screens/LoginScreen/LoginScre
 import { ExchangeScreenComponent } from "./Components/Screens/ExchangeScreen/ExchangeScreen.Component";
 import { ScreenLayoutComponent } from "./Components/Layout/ScreenLayout.Component";
 import {TrailingTradesComponent} from "./Components/Screens/TrailingTradesScreen/TrailingTrades.Component";
+import {GrowthTraderComponent} from "./Components/Screens/GrowthTraderScreen/GrowthTrader.Component";
 
 const routes: Routes = [
   {
@@ -13,6 +14,7 @@ const routes: Routes = [
       { path: 'login', component: LoginScreenComponent },
       { path: 'exchange', component: ExchangeScreenComponent },
       { path: 'trailing-trades', component: TrailingTradesComponent },
+      { path: 'growth-trader', component: GrowthTraderComponent },
       { path: '', redirectTo: '/login', pathMatch: 'full' },
     ]
   }

--- a/src/app/Components/Layout/ScreenLayout.Template.html
+++ b/src/app/Components/Layout/ScreenLayout.Template.html
@@ -9,6 +9,9 @@
   <button mat-button class="mat-button" routerLink="/trailing-trades">
     <span class="lead">Trade</span>
   </button>
+  <button mat-button class="mat-button" routerLink="/growth-trader">
+    <span class="lead">Growth Trader</span>
+  </button>
 </mat-toolbar>
 
 <router-outlet></router-outlet>

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Behaviors.ts
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Behaviors.ts
@@ -1,0 +1,7 @@
+import { GrowthTraderModel } from './GrowthTrader.Model';
+
+export class GrowthTraderBehaviors {
+  constructor(private readonly _data: GrowthTraderModel) {}
+
+  // Placeholder for future behaviors
+}

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Component.ts
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { GrowthTraderModel } from './GrowthTrader.Model';
+import { GrowthTraderBehaviors } from './GrowthTrader.Behaviors';
+import { GrowthTraderInteractions } from './GrowthTrader.Interactions';
+
+@Component({
+  selector: 'app-growth-trader-screen',
+  templateUrl: './GrowthTrader.Template.html',
+  styleUrls: ['./GrowthTrader.Styles.scss']
+})
+export class GrowthTraderComponent {
+  public readonly Model: GrowthTraderModel;
+  private readonly _behaviors: GrowthTraderBehaviors;
+  public readonly Interactions: GrowthTraderInteractions;
+
+  constructor() {
+    this.Model = new GrowthTraderModel();
+    this._behaviors = new GrowthTraderBehaviors(this.Model);
+    this.Interactions = new GrowthTraderInteractions(this._behaviors);
+  }
+}

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Interactions.ts
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Interactions.ts
@@ -1,0 +1,7 @@
+import { GrowthTraderBehaviors } from './GrowthTrader.Behaviors';
+
+export class GrowthTraderInteractions {
+  constructor(private readonly _behaviors: GrowthTraderBehaviors) {}
+
+  // Placeholder for future interactions
+}

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Model.ts
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Model.ts
@@ -1,0 +1,4 @@
+export class GrowthTraderModel {
+  constructor() {
+  }
+}

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Styles.scss
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Styles.scss
@@ -1,0 +1,3 @@
+.growth-trader-placeholder {
+  margin: 20px;
+}

--- a/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Template.html
+++ b/src/app/Components/Screens/GrowthTraderScreen/GrowthTrader.Template.html
@@ -1,0 +1,8 @@
+<div class="growth-trader-placeholder">
+  <mat-card>
+    <mat-card-title>Growth Trader</mat-card-title>
+    <mat-card-content>
+      <p>This screen is under construction.</p>
+    </mat-card-content>
+  </mat-card>
+</div>


### PR DESCRIPTION
## Summary
- add a new GrowthTrader screen placeholder
- wire GrowthTrader into routing, module, and navigation layout

## Testing
- `npm test` *(fails: ng not found)*