### PR TITLE
Add Growth Trading Options component

### DIFF
--- a/src/app/App.Module.ts
+++ b/src/app/App.Module.ts
@@ -22,6 +22,8 @@ import {MatSelectModule} from "@angular/material/select";
 import {TradeRowComponent} from "./Components/Screens/TrailingTradesScreen/TradeRow/TradeRow.Component";
 import {TextBoxComponent} from "./Components/Controls/TextBox/TextBox.Component";
 import {DropDownComponent} from "./Components/Controls/DropDown/DropDown.Component";
+import {GrowthTradingOptionsComponent} from "./Components/GrowthTradingOptions/GrowthTradingOptions.Component";
+import {MatTooltipModule} from "@angular/material/tooltip";
 
 @NgModule({
   declarations: [
@@ -33,7 +35,8 @@ import {DropDownComponent} from "./Components/Controls/DropDown/DropDown.Compone
     TrailingTradesComponent,
     TradeRowComponent,
     TextBoxComponent,
-    DropDownComponent
+    DropDownComponent,
+    GrowthTradingOptionsComponent
   ],
   imports: [
     BrowserModule,
@@ -50,7 +53,8 @@ import {DropDownComponent} from "./Components/Controls/DropDown/DropDown.Compone
     HttpClientModule,
     MatIconModule,
     MatSelectModule,
-    MatDividerModule
+    MatDividerModule,
+    MatTooltipModule
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Behaviors.ts
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Behaviors.ts
@@ -1,0 +1,10 @@
+import {GrowthTradingOptionsModel} from "./GrowthTradingOptions.Model";
+
+export class GrowthTradingOptionsBehaviors {
+  constructor(private readonly _model: GrowthTradingOptionsModel) {}
+
+  public Save() {
+    // Placeholder for saving configuration
+    console.log('Growth trading options saved', this._model.Options);
+  }
+}

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Component.ts
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Component.ts
@@ -1,0 +1,20 @@
+import {Component} from "@angular/core";
+import {GrowthTradingOptionsModel} from "./GrowthTradingOptions.Model";
+import {GrowthTradingOptionsBehaviors} from "./GrowthTradingOptions.Behaviors";
+import {GrowthTradingOptionsInteractions} from "./GrowthTradingOptions.Interactions";
+
+@Component({
+  selector: 'app-growth-trading-options',
+  templateUrl: './GrowthTradingOptions.Template.html',
+  styleUrls: ['./GrowthTradingOptions.Styles.scss']
+})
+export class GrowthTradingOptionsComponent {
+  public readonly Model: GrowthTradingOptionsModel;
+  public readonly Interactions: GrowthTradingOptionsInteractions;
+  private readonly _behaviors: GrowthTradingOptionsBehaviors;
+  constructor() {
+    this.Model = new GrowthTradingOptionsModel();
+    this._behaviors = new GrowthTradingOptionsBehaviors(this.Model);
+    this.Interactions = new GrowthTradingOptionsInteractions(this._behaviors);
+  }
+}

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Interactions.ts
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Interactions.ts
@@ -1,0 +1,9 @@
+import {GrowthTradingOptionsBehaviors} from "./GrowthTradingOptions.Behaviors";
+
+export class GrowthTradingOptionsInteractions {
+  constructor(private readonly _behaviors: GrowthTradingOptionsBehaviors) {}
+
+  public SaveButtonClicked() {
+    this._behaviors.Save();
+  }
+}

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Model.ts
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Model.ts
@@ -1,0 +1,12 @@
+import {GrowthTradingOptions} from "../../Domain/GrowthTradingOptions";
+import {GrowthTradingOptionsValidations} from "./GrowthTradingOptions.Validations";
+
+export class GrowthTradingOptionsModel {
+  constructor() {
+    this.Options = new GrowthTradingOptions();
+    this.Validations = new GrowthTradingOptionsValidations(this.Options);
+  }
+
+  public Options: GrowthTradingOptions;
+  public Validations: GrowthTradingOptionsValidations;
+}

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Styles.scss
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Styles.scss
@@ -1,0 +1,4 @@
+.options-card {
+  margin: 20px;
+  padding: 20px;
+}

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Template.html
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Template.html
@@ -1,0 +1,68 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col">
+      <mat-card class="options-card">
+        <mat-card-title>Growth Trading Options</mat-card-title>
+        <mat-card-content fxLayout="column" fxLayoutGap="10px">
+          <mat-form-field appearance="fill" matTooltip="When an asset grows by this percentage it will be automatically purchased.">
+            <mat-label>Growth Buy Trigger %</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.GrowthBuyTriggerPercent" placeholder="Enter percentage" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Percentage drop after purchase that triggers a sell.">
+            <mat-label>Trailing Stop Loss %</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.TrailingStopLossPercent" placeholder="Enter percentage" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Total capital to allocate for trading.">
+            <mat-label>Working Capital</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.WorkingCapital" placeholder="Amount available" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Minimum trade size in the base currency.">
+            <mat-label>Minimum Entry Size</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.MinimumEntrySize" placeholder="Minimum position" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Asset used when taking profit.">
+            <mat-label>Profit Base Asset</mat-label>
+            <input matInput [(ngModel)]="Model.Options.ProfitBaseAsset" placeholder="e.g. USDT" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Percentage of working assets to take when profit trigger fires.">
+            <mat-label>Take Profit %</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.TakeProfitPercent" placeholder="Enter percentage" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Growth percentage of the working assets required before taking profit.">
+            <mat-label>Take Profit Trigger %</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.TakeProfitTriggerPercent" placeholder="Enter percentage" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="If total working assets fall by this percent, all positions are closed.">
+            <mat-label>Total Stop Loss %</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.TotalStopLossPercent" placeholder="Enter percentage" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Profit amount in base currency that stops all trading when reached.">
+            <mat-label>Total Take Profit</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.TotalTakeProfitAmount" placeholder="Amount" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="How often positions are rebalanced (in minutes).">
+            <mat-label>Balancing Interval (min)</mat-label>
+            <input matInput type="number" [(ngModel)]="Model.Options.BalancingIntervalMinutes" placeholder="Minutes" />
+          </mat-form-field>
+
+          <mat-form-field appearance="fill" matTooltip="Total duration to run the strategy (e.g. 1d 2h).">
+            <mat-label>Run Length</mat-label>
+            <input matInput [(ngModel)]="Model.Options.RunLength" placeholder="Time span" />
+          </mat-form-field>
+        </mat-card-content>
+        <mat-card-actions fxLayoutAlign="end">
+          <button mat-raised-button color="primary" (click)="Interactions.SaveButtonClicked()">Save</button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+  </div>
+</div>

--- a/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Validations.ts
+++ b/src/app/Components/GrowthTradingOptions/GrowthTradingOptions.Validations.ts
@@ -1,0 +1,51 @@
+import {GrowthTradingOptions} from "../../Domain/GrowthTradingOptions";
+import {ValidationResult} from "../../Validation/Core/ValidationResult";
+import {Validations} from "../../Validation/Validations";
+
+export class GrowthTradingOptionsValidations {
+  constructor(private readonly _options: GrowthTradingOptions) {}
+
+  public get GrowthBuyTriggerPercent(): ValidationResult {
+    return Validations.Numeric(this._options.GrowthBuyTriggerPercent);
+  }
+
+  public get TrailingStopLossPercent(): ValidationResult {
+    return Validations.Numeric(this._options.TrailingStopLossPercent);
+  }
+
+  public get WorkingCapital(): ValidationResult {
+    return Validations.Numeric(this._options.WorkingCapital);
+  }
+
+  public get MinimumEntrySize(): ValidationResult {
+    return Validations.Numeric(this._options.MinimumEntrySize);
+  }
+
+  public get ProfitBaseAsset(): ValidationResult {
+    return Validations.NonEmptyString(this._options.ProfitBaseAsset);
+  }
+
+  public get TakeProfitPercent(): ValidationResult {
+    return Validations.Numeric(this._options.TakeProfitPercent);
+  }
+
+  public get TakeProfitTriggerPercent(): ValidationResult {
+    return Validations.Numeric(this._options.TakeProfitTriggerPercent);
+  }
+
+  public get TotalStopLossPercent(): ValidationResult {
+    return Validations.Numeric(this._options.TotalStopLossPercent);
+  }
+
+  public get TotalTakeProfitAmount(): ValidationResult {
+    return Validations.Numeric(this._options.TotalTakeProfitAmount);
+  }
+
+  public get BalancingIntervalMinutes(): ValidationResult {
+    return Validations.NonNegativeInteger(this._options.BalancingIntervalMinutes);
+  }
+
+  public get RunLength(): ValidationResult {
+    return Validations.NonEmptyString(this._options.RunLength);
+  }
+}

--- a/src/app/Domain/GrowthTradingOptions.ts
+++ b/src/app/Domain/GrowthTradingOptions.ts
@@ -1,0 +1,27 @@
+export class GrowthTradingOptions {
+  constructor() {
+    this.GrowthBuyTriggerPercent = '';
+    this.TrailingStopLossPercent = '';
+    this.WorkingCapital = '';
+    this.MinimumEntrySize = '';
+    this.ProfitBaseAsset = '';
+    this.TakeProfitPercent = '';
+    this.TakeProfitTriggerPercent = '';
+    this.TotalStopLossPercent = '';
+    this.TotalTakeProfitAmount = '';
+    this.BalancingIntervalMinutes = '';
+    this.RunLength = '';
+  }
+
+  public GrowthBuyTriggerPercent: string;
+  public TrailingStopLossPercent: string;
+  public WorkingCapital: string;
+  public MinimumEntrySize: string;
+  public ProfitBaseAsset: string;
+  public TakeProfitPercent: string;
+  public TakeProfitTriggerPercent: string;
+  public TotalStopLossPercent: string;
+  public TotalTakeProfitAmount: string;
+  public BalancingIntervalMinutes: string;
+  public RunLength: string;
+}


### PR DESCRIPTION
## Summary
- create GrowthTradingOptions domain model and validations
- implement GrowthTradingOptions component with template, styling, and behaviors
- register component with Angular module
- remove standalone route and place component in `Components` folder

## Testing
- `npm test` *(fails: Chrome failed to start)*