### PR TITLE
[admin] add mock api patch

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -1,0 +1,7 @@
+# Admin App Test Data
+
+This directory contains resources for development of the admin UI.
+It includes mock data used by `installTestApi` in `libs/ui` to
+patch the custom `HttpResourceApi` so calls to `/users` return
+predefined data. Import and invoke `installTestApi()` during
+testing or local development before any HTTP requests are made.

--- a/libs/ui/test-api.interceptor.ts
+++ b/libs/ui/test-api.interceptor.ts
@@ -1,0 +1,39 @@
+import { AxiosResponse } from 'axios';
+import { HttpResourceApi } from '../src/app/Core/HttpResourceApi';
+import { MOCK_USERS } from './test-data/users';
+
+/**
+ * Patches the custom `HttpResourceApi` so mock data can be returned
+ * at the last possible moment before an HTTP request is executed.
+ */
+let installed = false;
+
+export function installTestApi(): void {
+  if (installed) {
+    return;
+  }
+  installed = true;
+
+  const axios = (HttpResourceApi as any)._axios;
+  if (!axios) {
+    console.warn('Test API could not access HttpResourceApi axios instance');
+    return;
+  }
+
+  axios.interceptors.request.use((config) => {
+    const url = config.url?.replace('//', '/');
+    if (url && url.endsWith('/users')) {
+      config.adapter = async () => {
+        const response: AxiosResponse = {
+          data: MOCK_USERS,
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+        };
+        return Promise.resolve(response);
+      };
+    }
+    return config;
+  });
+}

--- a/libs/ui/test-data/users.ts
+++ b/libs/ui/test-data/users.ts
@@ -1,0 +1,10 @@
+export interface User {
+  id: number;
+  name: string;
+}
+
+export const MOCK_USERS: User[] = [
+  { id: 1, name: 'Alice' },
+  { id: 2, name: 'Bob' },
+  { id: 3, name: 'Charlie' }
+];


### PR DESCRIPTION
## Summary
- monkey patch `HttpResourceApi` to provide `/users` mock data
- explain how to enable the patch in admin README

The patch adds a helper that intercepts requests on the custom Axios instance, returning predefined user data without altering existing API calls.

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm test` *(fails to start Chrome)*
