### PR TITLE
[admin] Add comprehensive mock API data

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -4,3 +4,11 @@ This directory contains resources for development of the admin UI.
 It includes mock data used by `TestApiInterceptor` in `libs/ui` to
 simulate API responses at the last possible moment before network
 requests are sent.
+
+Currently provided mock datasets:
+
+- `users` – example user records
+- `accounts` – sample account information
+- `encryption-key` – a mock encryption key
+- `exchange` – exchange configuration data
+- `user-token` – token returned from user credential requests

--- a/libs/ui/test-api.interceptor.ts
+++ b/libs/ui/test-api.interceptor.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { MOCK_USERS } from './test-data/users';
+import { MOCK_ACCOUNTS } from './test-data/accounts';
+import { MOCK_ENCRYPTION_KEY } from './test-data/encryption-key';
+import { MOCK_EXCHANGE } from './test-data/exchange';
+import { MOCK_USER_TOKEN } from './test-data/user-token';
 
 /**
  * Intercepts HTTP calls to return mock data for development/testing.
@@ -12,6 +16,22 @@ export class TestApiInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     if (req.url.endsWith('/users')) {
       return of(new HttpResponse({ status: 200, body: MOCK_USERS }));
+    }
+
+    if (req.url.match(/\/accounts\/\d+$/) && req.method === 'GET') {
+      return of(new HttpResponse({ status: 200, body: MOCK_ACCOUNTS }));
+    }
+
+    if (req.url.match(/\/encryption-key\/\d+$/) && req.method === 'GET') {
+      return of(new HttpResponse({ status: 200, body: MOCK_ENCRYPTION_KEY }));
+    }
+
+    if (req.url.match(/\/exchange\/\d+$/) && req.method === 'GET') {
+      return of(new HttpResponse({ status: 200, body: MOCK_EXCHANGE }));
+    }
+
+    if (req.url.endsWith('/user-credentials/') && req.method === 'POST') {
+      return of(new HttpResponse({ status: 200, body: MOCK_USER_TOKEN }));
     }
 
     return next.handle(req);

--- a/libs/ui/test-data/accounts.ts
+++ b/libs/ui/test-data/accounts.ts
@@ -1,0 +1,13 @@
+export interface Account {
+  id: string;
+  currency: string;
+  type: string;
+  balance: number;
+  available: number;
+  holds: number;
+}
+
+export const MOCK_ACCOUNTS: Account[] = [
+  { id: 'acc1', currency: 'USD', type: 'trade', balance: 1000, available: 800, holds: 200 },
+  { id: 'acc2', currency: 'BTC', type: 'trade', balance: 2, available: 2, holds: 0 }
+];

--- a/libs/ui/test-data/encryption-key.ts
+++ b/libs/ui/test-data/encryption-key.ts
@@ -1,0 +1,11 @@
+export interface EncryptionKey {
+  id: number;
+  userId: number;
+  value: string;
+}
+
+export const MOCK_ENCRYPTION_KEY: EncryptionKey = {
+  id: 1,
+  userId: 1,
+  value: 'mock-encryption-key'
+};

--- a/libs/ui/test-data/exchange.ts
+++ b/libs/ui/test-data/exchange.ts
@@ -1,0 +1,15 @@
+export interface Exchange {
+  id: string;
+  apiVersion: string;
+  apiPublicKey: string;
+  apiPrivateKey: string;
+  apiKeyPassphrase: string;
+}
+
+export const MOCK_EXCHANGE: Exchange = {
+  id: 'exch1',
+  apiVersion: 'v1',
+  apiPublicKey: 'public',
+  apiPrivateKey: 'private',
+  apiKeyPassphrase: 'passphrase'
+};

--- a/libs/ui/test-data/user-token.ts
+++ b/libs/ui/test-data/user-token.ts
@@ -1,0 +1,11 @@
+export interface UserToken {
+  id: number;
+  userId: number;
+  token: string;
+}
+
+export const MOCK_USER_TOKEN: UserToken = {
+  id: 1,
+  userId: 1,
+  token: 'mock-token'
+};


### PR DESCRIPTION
## Summary
- expand mock API data to cover all admin endpoints
- intercept admin API requests for accounts, encryption keys, exchange data and login token
- document available datasets for the admin app

## Testing
- `pnpm lint`
- `pnpm test`
