### PR TITLE
[Codex] add domain unit tests

### DIFF
--- a/src/app/Domain/Application.spec.ts
+++ b/src/app/Domain/Application.spec.ts
@@ -1,0 +1,25 @@
+import { Application } from './Application';
+import { UserTokenResource } from '../Resources/UserTokenResource';
+
+describe('Application', () => {
+  beforeEach(() => {
+    Application.UserToken = new UserTokenResource();
+  });
+
+  describe('GetUserId', () => {
+    it('returns the user id when set', () => {
+      Application.UserToken.UserId = 7;
+      expect(Application.GetUserId()).toBe(7);
+    });
+
+    it('throws when user id is missing', () => {
+      Application.UserToken.UserId = 0;
+      expect(() => Application.GetUserId()).toThrowError('UserToken.UserId is null or undefined.');
+    });
+  });
+
+  it('generates a guid in the correct format', () => {
+    const guid = Application.NewGuid();
+    expect(guid).toMatch(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/);
+  });
+});

--- a/src/app/Domain/Exchange.spec.ts
+++ b/src/app/Domain/Exchange.spec.ts
@@ -1,0 +1,52 @@
+import { Exchange } from './Exchange';
+import { Application } from './Application';
+import { EncryptionKeyResource } from '../Resources/EncryptionKeyResource';
+
+const TEST_KEY = 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=';
+
+describe('Exchange', () => {
+  beforeEach(() => {
+    const key = new EncryptionKeyResource();
+    key.Value = TEST_KEY;
+    Application.EncryptionKey = key;
+  });
+
+  it('throws if encryption key is missing', () => {
+    Application.EncryptionKey.Value = '';
+    expect(() => new Exchange()).toThrowError('Application.EncryptionKey.Value is null or undefined.');
+  });
+
+  it('encrypts and decrypts api keys correctly', () => {
+    const exchange = new Exchange();
+    exchange.ApiPublicKey = 'PUB';
+    exchange.ApiPrivateKey = 'PRIV';
+    exchange.ApiKeyPassphrase = 'PASS';
+
+    expect(exchange.ApiPublicKey).toBe('PUB');
+    expect(exchange.ApiPrivateKey).toBe('PRIV');
+    expect(exchange.ApiKeyPassphrase).toBe('PASS');
+    expect(exchange.EncryptedApiPublicKey).not.toBe('PUB');
+  });
+
+  it('validation fails when fields are empty', () => {
+    const exchange = new Exchange();
+    const validations = exchange.Validations;
+    expect(validations.ApiPublicKey.IsValid).toBeFalse();
+    expect(validations.ApiPrivateKey.IsValid).toBeFalse();
+    expect(validations.ApiKeyPassphrase.IsValid).toBeFalse();
+  });
+
+  it('validation passes when fields are populated', () => {
+    const exchange = new Exchange();
+    exchange.ApiPublicKey = 'PUB';
+    exchange.ApiPrivateKey = 'PRIV';
+    exchange.ApiKeyPassphrase = 'PASS';
+    exchange.ApiVersion = '1';
+
+    const validations = exchange.Validations;
+    expect(validations.ApiPublicKey.IsValid).toBeTrue();
+    expect(validations.ApiPrivateKey.IsValid).toBeTrue();
+    expect(validations.ApiKeyPassphrase.IsValid).toBeTrue();
+    expect(validations.ApiVersion.IsValid).toBeTrue();
+  });
+});

--- a/src/app/Domain/GrowthTradingOptions.spec.ts
+++ b/src/app/Domain/GrowthTradingOptions.spec.ts
@@ -1,0 +1,18 @@
+import { GrowthTradingOptions } from './GrowthTradingOptions';
+
+describe('GrowthTradingOptions', () => {
+  it('initializes values to empty strings', () => {
+    const opts = new GrowthTradingOptions();
+    expect(opts.GrowthBuyTriggerPercent).toBe('');
+    expect(opts.TrailingStopLossPercent).toBe('');
+    expect(opts.WorkingCapital).toBe('');
+    expect(opts.MinimumEntrySize).toBe('');
+    expect(opts.ProfitBaseAsset).toBe('');
+    expect(opts.TakeProfitPercent).toBe('');
+    expect(opts.TakeProfitTriggerPercent).toBe('');
+    expect(opts.TotalStopLossPercent).toBe('');
+    expect(opts.TotalTakeProfitAmount).toBe('');
+    expect(opts.BalancingIntervalMinutes).toBe('');
+    expect(opts.RunLength).toBe('');
+  });
+});

--- a/src/app/Domain/Order.spec.ts
+++ b/src/app/Domain/Order.spec.ts
@@ -1,0 +1,21 @@
+import { Order } from './Order';
+import { Orders } from './Orders';
+import { Application } from './Application';
+
+describe('Order', () => {
+  it('attaches to Application.Orders when no parent is provided', () => {
+    Application.Orders = new Orders();
+    const order = new Order();
+    expect(Application.Orders.includes(order)).toBeTrue();
+    expect(order.Parent).toBe(Application.Orders);
+  });
+
+  it('delete removes order from parent', () => {
+    const orders = new Orders();
+    const order = new Order(orders);
+    orders.Attach(order);
+    expect(orders.includes(order)).toBeTrue();
+    order.Delete();
+    expect(orders.includes(order)).toBeFalse();
+  });
+});

--- a/src/app/Domain/Orders.spec.ts
+++ b/src/app/Domain/Orders.spec.ts
@@ -1,0 +1,32 @@
+import { Orders } from './Orders';
+import { Order } from './Order';
+import { Application } from './Application';
+
+describe('Orders', () => {
+  beforeEach(() => {
+    spyOn(Application, 'NewGuid').and.returnValue('GUID');
+  });
+
+  it('adds a new order with generated id', () => {
+    const orders = new Orders();
+    orders.Add();
+    expect(orders.length).toBe(1);
+    expect(orders[0].Id).toBe('GUID');
+    expect(Application.NewGuid).toHaveBeenCalled();
+  });
+
+  it('deletes an order', () => {
+    const orders = new Orders();
+    orders.Add();
+    const order = orders[0];
+    orders.Delete(order);
+    expect(orders.length).toBe(0);
+  });
+
+  it('attaches an external order', () => {
+    const orders = new Orders();
+    const ext = new Order(orders);
+    orders.Attach(ext);
+    expect(orders.includes(ext)).toBeTrue();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jasmine unit tests for domain models
- test Application utilities
- test Exchange encryption and validations
- test GrowthTradingOptions defaults
- test Orders collection and Order behaviors

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`
